### PR TITLE
no location restraint required in us-east-1, as it is the default by AWS

### DIFF
--- a/lib/create-bucket.js
+++ b/lib/create-bucket.js
@@ -9,13 +9,19 @@ function createBucket(name, region, s3lib) {
   if (!name || !region)
     return Promise.reject('Bucket name and region are required')
 
-  return s3lib.createBucket({
+  const options = {
     Bucket: name,
-    ACL: 'public-read',
-    CreateBucketConfiguration: {
+    ACL: 'public-read'
+  }
+
+  if(region !== 'us-east-1') {
+    options.CreateBucketConfiguration = {
       LocationConstraint: region
     }
-  }).promise()
+  }
+  
+  return s3lib.createBucket(options)
+    .promise()
     .then(result => result.Location)
 }
 

--- a/lib/scotty.js
+++ b/lib/scotty.js
@@ -91,7 +91,11 @@ function scotty(source, bucket, region, website, spa, update, force, quiet, logg
     })
     .then(response => {
       const cdnUrl = response && response.cdn ? response.url : null
-      const endpoint = website || spa ? `http://${bucket}.s3-website.${region}.amazonaws.com/` : `http://${bucket}.s3.amazonaws.com/`
+      const endpoint = website || spa ?
+        ( region === 'us-east-1' ?
+          `http://${bucket}.s3-website-${region}.amazonaws.com/` :
+          `http://${bucket}.s3-website.${region}.amazonaws.com/` ) :
+        `http://${bucket}.s3.amazonaws.com/`
 
       if (!quiet) {
         logger.log('\nSuccessfully beamed up!'.magenta, colors.cyan(endpoint), '\nThis link should be copied to your clipboard now.'.magenta)

--- a/spec/lib/create-bucket-spec.js
+++ b/spec/lib/create-bucket-spec.js
@@ -52,14 +52,26 @@ describe('Create a bucket', () => {
       .catch(done.fail)
   })
 
-  it('should invoke createBucket method of s3 class with options', done => {
+  it('should invoke createBucket method of s3 class with options (us-east-1)', done => {
     underTest('bucketName', 'us-east-1', s3spy)
+      .then(() => {
+        expect(s3spy.createBucket).toHaveBeenCalledWith({
+          Bucket: 'bucketName',
+          ACL: 'public-read'
+        })
+        done()
+      })
+      .catch(done.fail)
+  })
+
+  it('should invoke createBucket method of s3 class with options', done => {
+    underTest('bucketName', 'eu-central-1', s3spy)
       .then(() => {
         expect(s3spy.createBucket).toHaveBeenCalledWith({
           Bucket: 'bucketName',
           ACL: 'public-read',
           CreateBucketConfiguration: {
-            LocationConstraint: 'us-east-1'
+            LocationConstraint: 'eu-central-1'
           }
         })
         done()


### PR DESCRIPTION
Part II of the fix for  #[3](https://github.com/stojanovic/scottyjs/issues/3)