### PR TITLE
Fixed exit code so that CI systems don't bail after running scotty

### DIFF
--- a/bin/scotty.js
+++ b/bin/scotty.js
@@ -50,7 +50,7 @@ function showHelp() {
     ${colors.magenta('--source')}  ${colors.cyan('or')} ${colors.magenta('-s')}    Source of the folder that will be uploaded ${colors.cyan('| default: current folder')}
     ${colors.magenta('--bucket')}  ${colors.cyan('or')} ${colors.magenta('-b')}    Name of the S3 bucket ${colors.cyan('| default: name of the current folder')}
     ${colors.magenta('--region')}  ${colors.cyan('or')} ${colors.magenta('-r')}    AWS region where the files will be uploaded ${colors.cyan('| default: saved region if exists or a list to choose one if it is not saved yet')}
-    ${colors.magenta('--force')}   ${colors.cyan('or')} ${colors.magenta('-f')}    Update the bucket without asking, region can be overridden with ${colors.magenta('-r')} ${colors.cyan('| default: false')} 
+    ${colors.magenta('--force')}   ${colors.cyan('or')} ${colors.magenta('-f')}    Update the bucket without asking, region can be overridden with ${colors.magenta('-r')} ${colors.cyan('| default: false')}
     ${colors.magenta('--update')}  ${colors.cyan('or')} ${colors.magenta('-u')}    Update existing bucket ${colors.cyan('| default: false')}
 
     ✤ ✤ ✤
@@ -162,7 +162,7 @@ function cmd(console) {
 function beamUp (args, region, console) {
   return scotty(args.source, args.bucket, region, args.website, args.spa, args.update, args.force, args.quiet, console)
     .then(endpoint => clipboardy.write(endpoint))
-    .then(() => process.exit(1))
+    .then(() => process.exit(0))
     .catch(() => process.exit(1))
 }
 


### PR DESCRIPTION
We found that when running scotty and everything was uploaded and went fine that our CI system still failed the build.  Upon inspection, we noticed that scotty was returning a non-zero exit code, which was tell the CI server that scotty failed.  This fixes that so scotty only exits with a non 0 upon error.