### PR TITLE
Added the prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Deploy static websites or folders to AWS S3 with a single command
 [![npm](https://img.shields.io/npm/v/scottyjs.svg?maxAge=2592000?style=plastic)](https://www.npmjs.com/package/scottyjs)
 [![npm](https://img.shields.io/npm/dt/scottyjs.svg?maxAge=2592000?style=plastic)](https://www.npmjs.com/package/scottyjs)
 [![npm](https://img.shields.io/npm/l/scottyjs.svg?maxAge=2592000?style=plastic)](https://github.com/stojanovic/scottyjs/blob/master/LICENSE)
-[![Join the chat at https://gitter.im/scottyjs/scotty](https://badges.gitter.im/scottyjs/scotty.svg)](https://gitter.im/scottyjs/scotty?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)	
+[![Join the chat at https://gitter.im/scottyjs/scotty](https://badges.gitter.im/scottyjs/scotty.svg)](https://gitter.im/scottyjs/scotty?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Install
 
@@ -48,6 +48,7 @@ beam-me-up {options}
 - _--spa_ - Set uploaded folder as a single page app (default: false)
 - _--source_  or _-s_ - Source of the folder that will be uploaded (default: current folder)
 - _--bucket_ or _-b_ - Name of the S3 bucket (default: name of the current folder)
+- _--prefix_ or _-p_ - Prefix on the S3 bucket (default: the root of the bucket)
 - _--region_ or _-r_ - AWS region where the files will be uploaded, default: saved region if exists or a list to choose one if it is not saved yet
 - _--force_ or _-f_ - Update the bucket without asking (default: false, forced region can be overridden with _-r_)
 - _--update_ or _-u_ - Update existing bucket (default: false)
@@ -74,6 +75,22 @@ scotty --spa --source ./build --bucket some-bucket-name
 ```
 
 With `--spa` flag, Scotty will set required redirects for your single page app, so your app can use pushState out of the box.
+
+#### _Shared bucket_ application
+
+To deploy multiple apps to a single bucket you can make use of the `--prefix`
+option. This comes in handy when your CI system deploys to a staging system
+with each branch as a pathname. Eg. the `master` branch should go to bucket
+root (`/`), so you do not set the prefix. The `feature/fancy-stuff` branch
+should go to the bucket path `feature/fancy-stuff` so just add this as the
+prefix. Here comes a command line example:
+
+```shell
+# deploy your master branch build to bucket root
+scotty --source ./build --bucket some-bucket-name
+# deploy your branch build to the branch name on the bucket
+scotty --source_ ./build --bucket some-bucket-name --prefix your/branch
+```
 
 ## Test
 

--- a/bin/scotty.js
+++ b/bin/scotty.js
@@ -49,6 +49,7 @@ function showHelp() {
     ${colors.magenta('--spa')}              Set uploaded folder as a single page app and redirect all non-existing pages to index.html ${colors.cyan('| default: false')}
     ${colors.magenta('--source')}  ${colors.cyan('or')} ${colors.magenta('-s')}    Source of the folder that will be uploaded ${colors.cyan('| default: current folder')}
     ${colors.magenta('--bucket')}  ${colors.cyan('or')} ${colors.magenta('-b')}    Name of the S3 bucket ${colors.cyan('| default: name of the current folder')}
+    ${colors.magenta('--prefix')}  ${colors.cyan('or')} ${colors.magenta('-p')}    Prefix on the S3 bucket ${colors.cyan('| default: the root of the bucket')}
     ${colors.magenta('--region')}  ${colors.cyan('or')} ${colors.magenta('-r')}    AWS region where the files will be uploaded ${colors.cyan('| default: saved region if exists or a list to choose one if it is not saved yet')}
     ${colors.magenta('--force')}   ${colors.cyan('or')} ${colors.magenta('-f')}    Update the bucket without asking, region can be overridden with ${colors.magenta('-r')} ${colors.cyan('| default: false')}
     ${colors.magenta('--update')}  ${colors.cyan('or')} ${colors.magenta('-u')}    Update existing bucket ${colors.cyan('| default: false')}
@@ -72,16 +73,18 @@ function readArgs() {
       w: 'website',
       s: 'source',
       b: 'bucket',
+      p: 'prefix',
       r: 'region',
       f: 'force',
       u: 'update',
       d: 'delete'
     },
-    string: ['source', 'bucket', 'region'],
+    string: ['source', 'bucket', 'prefix', 'region'],
     boolean: ['quiet', 'website', 'spa', 'force', 'update', 'delete'],
     default: {
       source: process.cwd(),
-      bucket: path.parse(process.cwd()).name
+      bucket: path.parse(process.cwd()).name,
+      prefix: ''
     }
   })
 }
@@ -162,7 +165,7 @@ function cmd(console) {
 }
 
 function beamUp (args, region, console) {
-  return scotty(args.source, args.bucket, region, args.website, args.spa, args.update, args.delete, args.force, args.quiet, console)
+  return scotty(args.source, args.bucket, args.prefix, region, args.website, args.spa, args.update, args.delete, args.force, args.quiet, console)
     .then(endpoint => clipboardy.write(endpoint))
     .then(() => process.exit(0))
     .catch(() => process.exit(1))

--- a/lib/scotty.js
+++ b/lib/scotty.js
@@ -67,12 +67,14 @@ function destroyBucket(bucket, quiet, logger) {
     })
 }
 
-function scotty(source, bucket, region, website, spa, update, destroy, force, quiet, logger) {
+function scotty(source, bucket, prefix, region, website, spa, update, destroy, force, quiet, logger) {
   if (destroy)
     return destroyBucket(bucket, quiet, logger)
 
   if (!source || !bucket || !region)
     return Promise.reject('Source, bucket and region are required')
+
+  prefix = ((prefix || '') + '/').replace(/(\/)+$/, '/').replace(/^\/$/, '')
 
   return createOrUpdateBucket(bucket, region, update, force, quiet, logger)
     .then(result => {
@@ -80,7 +82,7 @@ function scotty(source, bucket, region, website, spa, update, destroy, force, qu
         logger.log('   bucket'.magenta, '✤', colors.cyan(result))
 
       time = new Date().getTime()
-      return upload(source, bucket)
+      return upload(source, bucket, prefix)
     })
     .then(() => {
       return new Promise((resolve, reject) => {
@@ -120,12 +122,12 @@ function scotty(source, bucket, region, website, spa, update, destroy, force, qu
       return true
     })
     .then(response => {
-      const cdnUrl = response && response.cdn ? response.url : null
+      const cdnUrl = response && response.cdn ? (`${response.url}/${prefix}`) : null
       const endpoint = website || spa ?
         ( region === 'us-east-1' ?
-          `http://${bucket}.s3-website-${region}.amazonaws.com/` :
-          `http://${bucket}.s3-website.${region}.amazonaws.com/` ) :
-        `http://${bucket}.s3.amazonaws.com/`
+          `http://${bucket}.s3-website-${region}.amazonaws.com/${prefix}` :
+          `http://${bucket}.s3-website.${region}.amazonaws.com/${prefix}` ) :
+        `http://${bucket}.s3.amazonaws.com/${prefix}`
 
       if (!quiet) {
         logger.log('\nSuccessfully beamed up!'.magenta, colors.cyan(endpoint), '\nThis link should be copied to your clipboard now.'.magenta)

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -5,6 +5,8 @@ const path = require('path')
 const uploadFile = require('./upload-file')
 
 function upload(source, bucket, prefix) {
+  prefix = prefix || ''
+
   return new Promise((resolve, reject) => {
     fs.readdir(source, (err, files) => {
       if (err)


### PR DESCRIPTION
**- What is it good for**

To deploy multiple apps to a single bucket you can make use of the `--prefix`
option. This comes in handy when your CI system deploys to a staging system
with each branch as a pathname. Eg. the `master` branch should go to bucket
root (`/`), so you do not set the prefix. The `feature/fancy-stuff` branch
should go to the bucket path `feature/fancy-stuff` so just add this as the
prefix. Here comes a command line example:  

```shell
# deploy your master branch build to bucket root
scotty --source ./build --bucket some-bucket-name
# deploy your branch build to the branch name on the bucket
scotty --source_ ./build --bucket some-bucket-name --prefix your/branch
```       

**- What I did**

* Updated the readme
* Added an input tolerant prefix option (allows (non)-trailing slashes)

**- What I did not**

Due to the tight coupling of the `lib/scotty` module to the `lib/upload` module was
not able to test the prefix input sanitization. I tried it and found myself in the middle
of a mock-the-whole-world situation and stopped it. If you can provide me a clever
solution how to test this I will do so. :)

**- A picture of a cute animal (not mandatory but encouraged)**

![cute-girl-cat-names](https://user-images.githubusercontent.com/2496275/31278070-e4cf2ed6-aaa3-11e7-8a26-a3ad99e1adc4.jpeg)