### PR TITLE
Added the no clipboard option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ beam-me-up {options}
 
 - _--help_ or _-h_ - Print this help
 - _--version_ or _-v_ - Print the current version
+- _--noclipboard_ or _-n_ - Do not copy the URL to clipboard (default: false)
 - _--quiet_ or _-q_ - Suppress output when executing commands (default: false)
 - _--website_ or _-w_ - Set uploaded folder as a static website (default: false)
 - _--spa_ - Set uploaded folder as a single page app (default: false)

--- a/bin/scotty.js
+++ b/bin/scotty.js
@@ -42,18 +42,19 @@ function showHelp() {
 
     AVAILABLE OPTIONS:
 
-    ${colors.magenta('--help')}    ${colors.cyan('or')} ${colors.magenta('-h')}    Print this help
-    ${colors.magenta('--version')} ${colors.cyan('or')} ${colors.magenta('-v')}    Print the current version
-    ${colors.magenta('--quiet')}   ${colors.cyan('or')} ${colors.magenta('-q')}    Suppress output when executing commands ${colors.cyan('| default: false')}
-    ${colors.magenta('--website')} ${colors.cyan('or')} ${colors.magenta('-w')}    Set uploaded folder as a static website ${colors.cyan('| default: false')}
-    ${colors.magenta('--spa')}              Set uploaded folder as a single page app and redirect all non-existing pages to index.html ${colors.cyan('| default: false')}
-    ${colors.magenta('--source')}  ${colors.cyan('or')} ${colors.magenta('-s')}    Source of the folder that will be uploaded ${colors.cyan('| default: current folder')}
-    ${colors.magenta('--bucket')}  ${colors.cyan('or')} ${colors.magenta('-b')}    Name of the S3 bucket ${colors.cyan('| default: name of the current folder')}
-    ${colors.magenta('--prefix')}  ${colors.cyan('or')} ${colors.magenta('-p')}    Prefix on the S3 bucket ${colors.cyan('| default: the root of the bucket')}
-    ${colors.magenta('--region')}  ${colors.cyan('or')} ${colors.magenta('-r')}    AWS region where the files will be uploaded ${colors.cyan('| default: saved region if exists or a list to choose one if it is not saved yet')}
-    ${colors.magenta('--force')}   ${colors.cyan('or')} ${colors.magenta('-f')}    Update the bucket without asking, region can be overridden with ${colors.magenta('-r')} ${colors.cyan('| default: false')}
-    ${colors.magenta('--update')}  ${colors.cyan('or')} ${colors.magenta('-u')}    Update existing bucket ${colors.cyan('| default: false')}
-    ${colors.magenta('--delete')}  ${colors.cyan('or')} ${colors.magenta('-d')}    Delete existing bucket ${colors.cyan('| default: false')}
+    ${colors.magenta('--help')}        ${colors.cyan('or')} ${colors.magenta('-h')}    Print this help
+    ${colors.magenta('--version')}     ${colors.cyan('or')} ${colors.magenta('-v')}    Print the current version
+    ${colors.magenta('--quiet')}       ${colors.cyan('or')} ${colors.magenta('-q')}    Suppress output when executing commands ${colors.cyan('| default: false')}
+    ${colors.magenta('--noclipboard')} ${colors.cyan('or')} ${colors.magenta('-n')}    Do not copy the URL to clipboard ${colors.cyan('| default: false')}
+    ${colors.magenta('--website')}     ${colors.cyan('or')} ${colors.magenta('-w')}    Set uploaded folder as a static website ${colors.cyan('| default: false')}
+    ${colors.magenta('--spa')}                  Set uploaded folder as a single page app and redirect all non-existing pages to index.html ${colors.cyan('| default: false')}
+    ${colors.magenta('--source')}      ${colors.cyan('or')} ${colors.magenta('-s')}    Source of the folder that will be uploaded ${colors.cyan('| default: current folder')}
+    ${colors.magenta('--bucket')}      ${colors.cyan('or')} ${colors.magenta('-b')}    Name of the S3 bucket ${colors.cyan('| default: name of the current folder')}
+    ${colors.magenta('--prefix')}      ${colors.cyan('or')} ${colors.magenta('-p')}    Prefix on the S3 bucket ${colors.cyan('| default: the root of the bucket')}
+    ${colors.magenta('--region')}      ${colors.cyan('or')} ${colors.magenta('-r')}    AWS region where the files will be uploaded ${colors.cyan('| default: saved region if exists or a list to choose one if it is not saved yet')}
+    ${colors.magenta('--force')}       ${colors.cyan('or')} ${colors.magenta('-f')}    Update the bucket without asking, region can be overridden with ${colors.magenta('-r')} ${colors.cyan('| default: false')}
+    ${colors.magenta('--update')}      ${colors.cyan('or')} ${colors.magenta('-u')}    Update existing bucket ${colors.cyan('| default: false')}
+    ${colors.magenta('--delete')}      ${colors.cyan('or')} ${colors.magenta('-d')}    Delete existing bucket ${colors.cyan('| default: false')}
 
     ✤ ✤ ✤
 
@@ -70,6 +71,7 @@ function readArgs() {
       h: 'help',
       v: 'version',
       q: 'quiet',
+      n: 'noclipboard',
       w: 'website',
       s: 'source',
       b: 'bucket',
@@ -165,8 +167,13 @@ function cmd(console) {
 }
 
 function beamUp (args, region, console) {
-  return scotty(args.source, args.bucket, args.prefix, region, args.website, args.spa, args.update, args.delete, args.force, args.quiet, console)
-    .then(endpoint => clipboardy.write(endpoint))
+  promise = scotty(args.source, args.bucket, args.prefix, region, args.website, args.spa, args.update, args.delete, args.force, args.quiet, !args.noclipboard, console)
+
+  if (!args.noclipboard) {
+    promise.then(endpoint => clipboardy.write(endpoint))
+  }
+
+  return promise
     .then(() => process.exit(0))
     .catch(() => process.exit(1))
 }

--- a/lib/scotty.js
+++ b/lib/scotty.js
@@ -67,7 +67,7 @@ function destroyBucket(bucket, quiet, logger) {
     })
 }
 
-function scotty(source, bucket, prefix, region, website, spa, update, destroy, force, quiet, logger) {
+function scotty(source, bucket, prefix, region, website, spa, update, destroy, force, quiet, clipboard, logger) {
   if (destroy)
     return destroyBucket(bucket, quiet, logger)
 
@@ -130,7 +130,12 @@ function scotty(source, bucket, prefix, region, website, spa, update, destroy, f
         `http://${bucket}.s3.amazonaws.com/${prefix}`
 
       if (!quiet) {
-        logger.log('\nSuccessfully beamed up!'.magenta, colors.cyan(endpoint), '\nThis link should be copied to your clipboard now.'.magenta)
+        logger.log('\nSuccessfully beamed up!'.magenta, colors.cyan(endpoint))
+
+        if (clipboard) {
+          logger.log('This link should be copied to your clipboard now.'.magenta)
+        }
+
         logger.log('\nCDN URL:'.magenta, colors.cyan(cdnUrl), '\nCloudFront is super slow, this link should be valid in next 10 minutes or so.'.magenta)
       }
 


### PR DESCRIPTION
**- What is it good for**

Looks like on CI conditions the clipboard copying fails. With the new option you can
configure shottyjs to skip the clipboard handling. With this option the CI build failed
no more.

**- What I did**

* Updated the readme
* Added `--noclipboard` option to disable clipboardy

**- What I did not**

Due to the tight coupling of the `bin/scotty` binary to the `lib/scotty` module was
not able to test the new option. If you can provide me a clever solution how to
test this I will do so. :)

**- A picture of a cute animal (not mandatory but encouraged)**

![images](https://user-images.githubusercontent.com/2496275/31283387-be8773b6-aab5-11e7-874e-d48a46e5f16c.jpeg)