### PR TITLE
Add multiple new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ beam-me-up {options}
 - _--force_ or _-f_ - Update the bucket without asking (default: false, forced region can be overridden with _-r_)
 - _--update_ or _-u_ - Update existing bucket (default: false)
 - _--delete_ or _-d_ - Delete existing bucket (default: false)
+- _--nocdn_ or _-c_ - Disable Cloudfront handling (default: false)
+- _--urlonly_ or _-o_ - Only output the resulting URL, CDN or S3 according to options (default: false)
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ beam-me-up {options}
 - _--delete_ or _-d_ - Delete existing bucket (default: false)
 - _--nocdn_ or _-c_ - Disable Cloudfront handling (default: false)
 - _--urlonly_ or _-o_ - Only output the resulting URL, CDN or S3 according to options (default: false)
+- _--expire_ or _-e_ - elete objects on bucket older than n days (default: no expiration)
 
 ### Examples
 

--- a/bin/scotty.js
+++ b/bin/scotty.js
@@ -55,6 +55,8 @@ function showHelp() {
     ${colors.magenta('--force')}       ${colors.cyan('or')} ${colors.magenta('-f')}    Update the bucket without asking, region can be overridden with ${colors.magenta('-r')} ${colors.cyan('| default: false')}
     ${colors.magenta('--update')}      ${colors.cyan('or')} ${colors.magenta('-u')}    Update existing bucket ${colors.cyan('| default: false')}
     ${colors.magenta('--delete')}      ${colors.cyan('or')} ${colors.magenta('-d')}    Delete existing bucket ${colors.cyan('| default: false')}
+    ${colors.magenta('--nocdn')}       ${colors.cyan('or')} ${colors.magenta('-c')}    Disable Cloudfront handling ${colors.cyan('| default: false')}
+    ${colors.magenta('--urlonly')}     ${colors.cyan('or')} ${colors.magenta('-o')}    Only output the resulting URL, CDN or S3 according to options ${colors.cyan('| default: false')}
 
     ✤ ✤ ✤
 
@@ -79,7 +81,9 @@ function readArgs() {
       r: 'region',
       f: 'force',
       u: 'update',
-      d: 'delete'
+      d: 'delete',
+      c: 'nocdn',
+      o: 'urlonly'
     },
     string: ['source', 'bucket', 'prefix', 'region'],
     boolean: ['quiet', 'website', 'spa', 'force', 'update', 'delete'],
@@ -167,7 +171,7 @@ function cmd(console) {
 }
 
 function beamUp (args, region, console) {
-  promise = scotty(args.source, args.bucket, args.prefix, region, args.website, args.spa, args.update, args.delete, args.force, args.quiet, !args.noclipboard, console)
+  promise = scotty(args.source, args.bucket, args.prefix, region, args.website, args.spa, args.update, args.delete, args.nocdn, args.urlonly, args.force, args.quiet, !args.noclipboard, console)
 
   if (!args.noclipboard) {
     promise.then(endpoint => clipboardy.write(endpoint))

--- a/bin/scotty.js
+++ b/bin/scotty.js
@@ -57,6 +57,7 @@ function showHelp() {
     ${colors.magenta('--delete')}      ${colors.cyan('or')} ${colors.magenta('-d')}    Delete existing bucket ${colors.cyan('| default: false')}
     ${colors.magenta('--nocdn')}       ${colors.cyan('or')} ${colors.magenta('-c')}    Disable Cloudfront handling ${colors.cyan('| default: false')}
     ${colors.magenta('--urlonly')}     ${colors.cyan('or')} ${colors.magenta('-o')}    Only output the resulting URL, CDN or S3 according to options ${colors.cyan('| default: false')}
+    ${colors.magenta('--expire')}      ${colors.cyan('or')} ${colors.magenta('-e')}    Delete objects on bucket older than n days ${colors.cyan('| default: no expiration')}
 
     ✤ ✤ ✤
 
@@ -83,7 +84,8 @@ function readArgs() {
       u: 'update',
       d: 'delete',
       c: 'nocdn',
-      o: 'urlonly'
+      o: 'urlonly',
+      e: 'expire'
     },
     string: ['source', 'bucket', 'prefix', 'region'],
     boolean: ['quiet', 'website', 'spa', 'force', 'update', 'delete'],
@@ -171,7 +173,7 @@ function cmd(console) {
 }
 
 function beamUp (args, region, console) {
-  promise = scotty(args.source, args.bucket, args.prefix, region, args.website, args.spa, args.update, args.delete, args.nocdn, args.urlonly, args.force, args.quiet, !args.noclipboard, console)
+  promise = scotty(args.source, args.bucket, args.prefix, region, args.website, args.spa, args.update, args.delete, args.nocdn, args.urlonly, args.expire, args.force, args.quiet, !args.noclipboard, console)
 
   if (!args.noclipboard) {
     promise.then(endpoint => clipboardy.write(endpoint))

--- a/lib/scotty.js
+++ b/lib/scotty.js
@@ -128,11 +128,11 @@ function scotty(source, bucket, prefix, region, website, spa, update, destroy, n
     })
     .then(response => {
       const cdnUrl = response && response.cdn ? (`${response.url}/${prefix}`) : null
-      const endpoint = website || spa ?
-        ( region === 'us-east-1' ?
-          `http://${bucket}.s3-website-${region}.amazonaws.com/${prefix}` :
-          `http://${bucket}.s3-website.${region}.amazonaws.com/${prefix}` ) :
-        `http://${bucket}.s3.amazonaws.com/${prefix}`
+
+      // See: http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html
+      const endpoint = website || spa
+        ? `http://${bucket}.s3-website-${region}.amazonaws.com/${prefix}`
+        : `http://${bucket}.s3.amazonaws.com/${prefix}`
 
       if (urlonly) {
         logger.log(nocdn ? endpoint : cdnUrl)

--- a/lib/scotty.js
+++ b/lib/scotty.js
@@ -9,6 +9,7 @@ const reuseBucket = require('./reuse-bucket')
 const upload = require('./upload')
 const getFormattedSize = require('./get-formatted-size')
 const setAsWebsite = require('./set-as-website')
+const setExpirationDays = require('./set-expiration-days')
 const setCdn = require('./set-cdn')
 
 let time = new Date()
@@ -67,7 +68,7 @@ function destroyBucket(bucket, quiet, logger) {
     })
 }
 
-function scotty(source, bucket, prefix, region, website, spa, update, destroy, nocdn, urlonly, force, quiet, clipboard, logger) {
+function scotty(source, bucket, prefix, region, website, spa, update, destroy, nocdn, urlonly, expire, force, quiet, clipboard, logger) {
   if (destroy)
     return destroyBucket(bucket, quiet, logger)
 
@@ -101,6 +102,14 @@ function scotty(source, bucket, prefix, region, website, spa, update, destroy, n
           resolve()
         })
       })
+    })
+    .then(() => {
+      if (expire) {
+        if (!quiet)
+          logger.log('   config'.magenta, '✤', 'set expiration days'.cyan)
+
+        return setExpirationDays(bucket, prefix, expire)
+      }
     })
     .then(() => {
       if (website || spa) {
@@ -145,7 +154,9 @@ function scotty(source, bucket, prefix, region, website, spa, update, destroy, n
           logger.log('This link should be copied to your clipboard now.'.magenta)
         }
 
-        logger.log('\nCDN URL:'.magenta, colors.cyan(cdnUrl), '\nCloudFront is super slow, this link should be valid in next 10 minutes or so.'.magenta)
+        if (cdnUrl) {
+          logger.log('\nCDN URL:'.magenta, colors.cyan(cdnUrl), '\nCloudFront is super slow, this link should be valid in next 10 minutes or so.'.magenta)
+        }
       }
 
       return endpoint

--- a/lib/scotty.js
+++ b/lib/scotty.js
@@ -67,12 +67,15 @@ function destroyBucket(bucket, quiet, logger) {
     })
 }
 
-function scotty(source, bucket, prefix, region, website, spa, update, destroy, force, quiet, clipboard, logger) {
+function scotty(source, bucket, prefix, region, website, spa, update, destroy, nocdn, urlonly, force, quiet, clipboard, logger) {
   if (destroy)
     return destroyBucket(bucket, quiet, logger)
 
   if (!source || !bucket || !region)
     return Promise.reject('Source, bucket and region are required')
+
+  if (urlonly)
+    quiet = true
 
   prefix = ((prefix || '') + '/').replace(/(\/)+$/, '/').replace(/^\/$/, '')
 
@@ -106,10 +109,12 @@ function scotty(source, bucket, prefix, region, website, spa, update, destroy, f
 
         return setAsWebsite(bucket, spa)
           .then(() => {
-            if (!quiet)
-              logger.log('   config'.magenta, '✤', 'set cdn'.cyan)
+            if (!nocdn) {
+              if (!quiet)
+                logger.log('   config'.magenta, '✤', 'set cdn'.cyan)
 
-            return setCdn(bucket)
+              return setCdn(bucket)
+            }
           })
           .then(domainName => {
             return {
@@ -128,6 +133,10 @@ function scotty(source, bucket, prefix, region, website, spa, update, destroy, f
           `http://${bucket}.s3-website-${region}.amazonaws.com/${prefix}` :
           `http://${bucket}.s3-website.${region}.amazonaws.com/${prefix}` ) :
         `http://${bucket}.s3.amazonaws.com/${prefix}`
+
+      if (urlonly) {
+        logger.log(nocdn ? endpoint : cdnUrl)
+      }
 
       if (!quiet) {
         logger.log('\nSuccessfully beamed up!'.magenta, colors.cyan(endpoint))

--- a/lib/set-expiration-days.js
+++ b/lib/set-expiration-days.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const AWS = require('aws-sdk')
+const s3 = new AWS.S3()
+
+function setExpirationDays(bucket, prefix, days) {
+  const prefixName = (prefix || '/')
+    .replace(/[^a-z0-9-]/gi, '-')
+    .replace(/^-$/, 'no-prefix')
+    .replace(/^-/, '')
+    .replace(/-$/, '')
+  const scottyRuleId = `scotty-expiration-${prefixName}`
+
+  return s3.getBucketLifecycleConfiguration({
+    Bucket: bucket
+  })
+    .promise()
+    .catch(() => { return {Rules: []} })
+    .then((data) => {
+      let rules = data.Rules
+      const ruleExists = rules.filter((rule) => rule.ID === scottyRuleId).length > 0
+      const currentRule = {
+        ID: scottyRuleId,
+        Expiration: {
+          Days: days
+        },
+        Filter: {
+          Prefix: prefix || ''
+        },
+        Status: 'Enabled',
+        NoncurrentVersionExpiration: {
+          NoncurrentDays: days
+        },
+        AbortIncompleteMultipartUpload: {
+          DaysAfterInitiation: 7
+        }
+      }
+
+      if (ruleExists) {
+        rules = rules.filter((rule) => rule.ID !== scottyRuleId)
+      }
+      rules.push(currentRule)
+
+      return s3.putBucketLifecycleConfiguration({
+        Bucket: bucket,
+        LifecycleConfiguration: {
+          Rules: rules
+        }
+      })
+        .promise()
+    })
+}
+
+module.exports = setExpirationDays


### PR DESCRIPTION
**- What is it good for**

Sometimes it could be handy to be able to disable Cloudfront as well as just output the resulting URL of the CDN/S3 bucket. Last but not least setting a lifecycle for object expiration could be handy, too. With this PR we are able to expire S3 objects based on the given prefix and the given amount of days. Only output the resulting URL can be handy on scripted usage.

**- What I did**

* Updated the readme
* Added `--nocdn` option to disable Cloudfront handling
* Added `--urlonly` option to only output resulting URLs
* Added `--expire` option to enable an expiration lifecycle (with prefix relation if set)
* Fixed the broken S3 URL formats (http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html)
  * Looks like there is no us-east-1 special case anymore (non us-east-1 regions not working like this)

**- What I did not**

Tests are missing. :cry: 

**- A picture of a cute animal (not mandatory but encouraged)**
![images](https://user-images.githubusercontent.com/2496275/31449744-07297894-aea8-11e7-9495-ac7404a7ef58.jpeg)