### PR TITLE
[Bugfix] Fix aws profile configuration for S3 clients.

### DIFF
--- a/bin/scotty.js
+++ b/bin/scotty.js
@@ -200,7 +200,8 @@ function cmd(console) {
 }
 
 function beamUp (args, region, console) {
-  promise = scotty(args.source, args.bucket, args.prefix, region, args.website, args.spa, args.update, args.delete, args.nocdn, args.urlonly, args.expire, args.force, args.quiet, !args.noclipboard, console)
+  const s3 = new AWS.S3()
+  promise = scotty(args.source, args.bucket, args.prefix, region, args.website, args.spa, args.update, args.delete, args.nocdn, args.urlonly, args.expire, args.force, args.quiet, !args.noclipboard, console, s3)
 
   if (!args.noclipboard) {
     promise.then(endpoint => clipboardy.write(endpoint))

--- a/lib/scotty.js
+++ b/lib/scotty.js
@@ -13,12 +13,13 @@ const setExpirationDays = require('./set-expiration-days')
 const setCdn = require('./set-cdn')
 
 let time = new Date()
+let s3lib
 
 function createOrUpdateBucket(bucket, region, update, force, quiet, logger) {
   if (update)
     return Promise.resolve(bucket)
 
-  return createBucket(bucket, region)
+  return createBucket(bucket, region, s3lib)
     .then(location => {
       if (!quiet)
         logger.log('   create'.magenta, '✤', colors.cyan(`${location} bucket`))
@@ -48,7 +49,7 @@ function destroyBucket(bucket, quiet, logger) {
 
   if (!quiet)
     logger.log('   empty'.magenta, '✤', colors.cyan(`${bucket} bucket`))
-  return deleteBucket(bucket)
+  return deleteBucket(bucket, s3lib)
     .then(bucket => {
       if (!quiet)
         logger.log('   delete'.magenta, '✤', colors.cyan(`${bucket} bucket`))
@@ -68,7 +69,11 @@ function destroyBucket(bucket, quiet, logger) {
     })
 }
 
-function scotty(source, bucket, prefix, region, website, spa, update, destroy, nocdn, urlonly, expire, force, quiet, clipboard, logger) {
+function scotty(source, bucket, prefix, region, website, spa, update, destroy, nocdn, urlonly, expire, force, quiet, clipboard, logger, s3client) {
+
+  if (s3client)
+    s3lib = s3client
+
   if (destroy)
     return destroyBucket(bucket, quiet, logger)
 
@@ -108,7 +113,7 @@ function scotty(source, bucket, prefix, region, website, spa, update, destroy, n
         if (!quiet)
           logger.log('   config'.magenta, '✤', 'set expiration days'.cyan)
 
-        return setExpirationDays(bucket, prefix, expire)
+        return setExpirationDays(bucket, prefix, expire, s3lib)
       }
     })
     .then(() => {
@@ -116,7 +121,7 @@ function scotty(source, bucket, prefix, region, website, spa, update, destroy, n
         if (!quiet)
           logger.log('   config'.magenta, '✤', 'set as a website'.cyan)
 
-        return setAsWebsite(bucket, spa)
+        return setAsWebsite(bucket, spa, s3lib)
           .then(() => {
             if (!nocdn) {
               if (!quiet)

--- a/lib/scotty.js
+++ b/lib/scotty.js
@@ -91,7 +91,7 @@ function scotty(source, bucket, prefix, region, website, spa, update, destroy, n
         logger.log('   bucket'.magenta, '✤', colors.cyan(result))
 
       time = new Date().getTime()
-      return upload(source, bucket, prefix)
+      return upload(source, bucket, prefix, s3lib)
     })
     .then(() => {
       return new Promise((resolve, reject) => {

--- a/lib/set-as-website.js
+++ b/lib/set-as-website.js
@@ -3,8 +3,10 @@
 const AWS = require('aws-sdk')
 const s3 = new AWS.S3()
 
-function setAsWebsite(bucket, isSpa) {
-  return s3.putBucketWebsite({
+function setAsWebsite(bucket, isSpa, s3lib) {
+  s3lib = s3lib || s3
+
+  return s3lib.putBucketWebsite({
     Bucket: bucket,
     ContentMD5: '',
     WebsiteConfiguration: {

--- a/lib/set-expiration-days.js
+++ b/lib/set-expiration-days.js
@@ -3,7 +3,9 @@
 const AWS = require('aws-sdk')
 const s3 = new AWS.S3()
 
-function setExpirationDays(bucket, prefix, days) {
+function setExpirationDays(bucket, prefix, days, s3lib) {
+  s3lib = s3lib || s3
+
   const prefixName = (prefix || '/')
     .replace(/[^a-z0-9-]/gi, '-')
     .replace(/^-$/, 'no-prefix')
@@ -11,7 +13,7 @@ function setExpirationDays(bucket, prefix, days) {
     .replace(/-$/, '')
   const scottyRuleId = `scotty-expiration-${prefixName}`
 
-  return s3.getBucketLifecycleConfiguration({
+  return s3lib.getBucketLifecycleConfiguration({
     Bucket: bucket
   })
     .promise()

--- a/lib/upload-file.js
+++ b/lib/upload-file.js
@@ -5,7 +5,8 @@ const mime = require('mime')
 const AWS = require('aws-sdk')
 const s3 = new AWS.S3()
 
-function uploadFile(fileName, filePath, bucket, prefix) {
+function uploadFile(fileName, filePath, bucket, prefix, s3lib) {
+  s3lib = s3lib || s3
   prefix = prefix || ''
 
   return new Promise((resolve, reject) => {
@@ -17,7 +18,7 @@ function uploadFile(fileName, filePath, bucket, prefix) {
     })
   })
     .then(fileContent => {
-      return s3.putObject({
+      return s3lib.putObject({
         Bucket: bucket,
         Key: prefix + fileName,
         ContentType: mime.lookup(fileName),

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const uploadFile = require('./upload-file')
 
-function upload(source, bucket, prefix) {
+function upload(source, bucket, prefix, s3lib) {
   prefix = prefix || ''
 
   return new Promise((resolve, reject) => {
@@ -27,7 +27,7 @@ function upload(source, bucket, prefix) {
         if (fs.lstatSync(filePath).isDirectory())
           return upload(filePath, bucket, (prefix ? prefix : '') + file + '/')
 
-        return uploadFile(file, filePath, bucket, prefix || '')
+        return uploadFile(file, filePath, bucket, prefix || '', s3lib)
       }))
     })
 }


### PR DESCRIPTION
Before, the S3 clients in each lib module were instantiating upon initial require, so mutating the global AWS configuration by setting a different profile did not propagate and all S3 clients used the "default" profile. This PR expands on the dependency injection pattern which was established in the code for "s3lib" and uses it when applicable.